### PR TITLE
made seedkit_tag optional

### DIFF
--- a/aws_codeseeder/services/cfn.py
+++ b/aws_codeseeder/services/cfn.py
@@ -170,7 +170,7 @@ def does_stack_exist(stack_name: str) -> Tuple[bool, Dict[str, str]]:
 def deploy_template(
     stack_name: str,
     filename: str,
-    seedkit_tag: str,
+    seedkit_tag: Optional[str] = None,
     s3_bucket: Optional[str] = None,
     parameters: Optional[Dict[str, str]] = None,
 ) -> None:


### PR DESCRIPTION
Made `seedkit_tag` optional so we dont have to tag during every changeset execution

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
