### PR TITLE
Feature/lazy deploy seedkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
-* lazy deploy the SeedKit Stack when `deploy_if_not_exists` is configured
+* JIT deployment the SeedKit Stack when `deploy_if_not_exists` is configured
 
 ### Breaks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ---
 
 ### New
+* thread safe JIT Seedkit deployment
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+* lazy deploy the SeedKit Stack when `deploy_if_not_exists` is configured
 
 ### Breaks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
-* JIT deployment the SeedKit Stack when `deploy_if_not_exists` is configured
+* JIT deployment of the SeedKit Stack when `deploy_if_not_exists` is configured
 
 ### Breaks
 

--- a/aws_codeseeder/_classes.py
+++ b/aws_codeseeder/_classes.py
@@ -14,6 +14,7 @@
 
 import dataclasses
 import enum
+import threading
 from typing import Any, Callable, Dict, List, Optional, cast
 
 from mypy_extensions import KwArg, NamedArg, VarArg
@@ -107,3 +108,4 @@ class RegistryEntry:
     stack_outputs: Optional[Dict[str, str]] = None
     remote_functions: Dict[str, RemoteFunctionFn] = dataclasses.field(default_factory=dict)
     deploy_if_not_exists: bool = False
+    lock: threading.Lock = dataclasses.field(default_factory=threading.Lock)

--- a/aws_codeseeder/_classes.py
+++ b/aws_codeseeder/_classes.py
@@ -106,3 +106,4 @@ class RegistryEntry:
     config_object: CodeSeederConfig = CodeSeederConfig()
     stack_outputs: Optional[Dict[str, str]] = None
     remote_functions: Dict[str, RemoteFunctionFn] = dataclasses.field(default_factory=dict)
+    deploy_if_not_exists: bool = False

--- a/aws_codeseeder/codeseeder.py
+++ b/aws_codeseeder/codeseeder.py
@@ -258,15 +258,16 @@ def remote_function(
                 return result
             else:
                 stack_name = cfn.get_stack_name(seedkit_name=seedkit_name)
-                while True:
-                    stack_exists, stack_outputs = cfn.does_stack_exist(stack_name=stack_name)
-                    if not stack_exists and registry_entry.deploy_if_not_exists:
-                        deploy_seedkit(seedkit_name=seedkit_name)
-                    elif not stack_exists:
-                        raise ValueError(f"Seedkit/Stack named {seedkit_name} is not yet deployed")
-                    else:
-                        registry_entry.stack_outputs = stack_outputs
-                        break
+                with registry_entry.lock:
+                    while True:
+                        stack_exists, stack_outputs = cfn.does_stack_exist(stack_name=stack_name)
+                        if not stack_exists and registry_entry.deploy_if_not_exists:
+                            deploy_seedkit(seedkit_name=seedkit_name)
+                        elif not stack_exists:
+                            raise ValueError(f"Seedkit/Stack named {seedkit_name} is not yet deployed")
+                        else:
+                            registry_entry.stack_outputs = stack_outputs
+                            break
 
                 # Bundle and execute remotely in codebuild
                 LOGGER.info("Beginning Remote Execution: %s", fn_id)

--- a/aws_codeseeder/codeseeder.py
+++ b/aws_codeseeder/codeseeder.py
@@ -64,16 +64,9 @@ def configure(seedkit_name: str, deploy_if_not_exists: bool = False) -> Configur
     """
 
     def decorator(func: _classes.ConfigureFn) -> _classes.ConfigureFn:
-        stack_name = cfn.get_stack_name(seedkit_name=seedkit_name)
-        while True:
-            stack_exists, stack_outputs = cfn.does_stack_exist(stack_name=stack_name)
-            if not stack_exists and deploy_if_not_exists:
-                deploy_seedkit(seedkit_name=seedkit_name)
-            elif not stack_exists:
-                raise ValueError(f"Seedkit/Stack named {seedkit_name} is not yet deployed")
-            else:
-                break
-        SEEDKIT_REGISTRY[seedkit_name] = _classes.RegistryEntry(config_function=func, stack_outputs=stack_outputs)
+        SEEDKIT_REGISTRY[seedkit_name] = _classes.RegistryEntry(
+            config_function=func, deploy_if_not_exists=deploy_if_not_exists
+        )
 
         return func
 
@@ -171,19 +164,14 @@ def remote_function(
     """
 
     def decorator(func: Callable[..., Any]) -> _classes.RemoteFunctionFn:
-        stack_name = cfn.get_stack_name(seedkit_name=seedkit_name)
-        stack_exists, stack_outputs = cfn.does_stack_exist(stack_name=stack_name)
-        if not stack_exists:
-            raise ValueError(f"Seedkit/Stack named {seedkit_name} is not yet deployed")
         if seedkit_name not in SEEDKIT_REGISTRY:
-            SEEDKIT_REGISTRY[seedkit_name] = _classes.RegistryEntry(stack_outputs=stack_outputs)
+            SEEDKIT_REGISTRY[seedkit_name] = _classes.RegistryEntry()
+        registry_entry = SEEDKIT_REGISTRY[seedkit_name]
+        config_object = registry_entry.config_object
 
         fn_module = function_module if function_module else func.__module__
         fn_name = function_name if function_name else func.__name__
         fn_id = f"{fn_module}:{fn_name}"
-
-        registry_entry = SEEDKIT_REGISTRY[seedkit_name]
-        config_object = registry_entry.config_object
 
         python_modules = decorator.python_modules  # type: ignore
         local_modules = decorator.local_modules  # type: ignore
@@ -269,11 +257,21 @@ def remote_function(
                         file.write("export AWS_CODESEEDER_OUTPUT")
                 return result
             else:
+                stack_name = cfn.get_stack_name(seedkit_name=seedkit_name)
+                while True:
+                    stack_exists, stack_outputs = cfn.does_stack_exist(stack_name=stack_name)
+                    if not stack_exists and registry_entry.deploy_if_not_exists:
+                        deploy_seedkit(seedkit_name=seedkit_name)
+                    elif not stack_exists:
+                        raise ValueError(f"Seedkit/Stack named {seedkit_name} is not yet deployed")
+                    else:
+                        registry_entry.stack_outputs = stack_outputs
+                        break
+
                 # Bundle and execute remotely in codebuild
                 LOGGER.info("Beginning Remote Execution: %s", fn_id)
                 fn_args = {"fn_id": fn_id, "args": args, "kwargs": kwargs}
                 LOGGER.debug("fn_args: %s", fn_args)
-                registry_entry = SEEDKIT_REGISTRY[seedkit_name]
                 stack_outputs = registry_entry.stack_outputs
 
                 cmds_install = [
@@ -304,7 +302,7 @@ def remote_function(
                     fn_args=fn_args, dirs=dirs_tuples, files=files_tuples, bundle_id=bundle_id
                 )
                 buildspec = codebuild.generate_spec(
-                    stack_outputs=cast(Dict[str, str], stack_outputs),
+                    stack_outputs=stack_outputs,
                     cmds_install=cmds_install + install_commands,
                     cmds_pre=[
                         ". ~/.venv/bin/activate",
@@ -346,7 +344,7 @@ def remote_function(
                     ]
 
                 build_info = _remote.run(
-                    stack_outputs=cast(Dict[str, str], stack_outputs),
+                    stack_outputs=stack_outputs,
                     bundle_path=bundle_zip,
                     buildspec=buildspec,
                     timeout=timeout if timeout else config_object.timeout if config_object.timeout else 30,

--- a/example/my_example/cli.py
+++ b/example/my_example/cli.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import logging
 import os
 from typing import Dict, Optional
@@ -113,6 +114,7 @@ def remote_hello_world_2(name: str) -> str:
         extra_files={"VERSION": os.path.realpath(os.path.join(CLI_ROOT, "../VERSION"))},
         extra_post_build_commands=[f"export ANOTHER_EXPORTED_VAR='{name}'"],
         extra_exported_env_vars=["ANOTHER_EXPORTED_VAR"],
+        bundle_id=name,
     )
     def remote_hello_world_2(name: str) -> str:
         print(f"[RESULT] {name}")
@@ -153,11 +155,16 @@ def main() -> None:
 
     deploy_test_stack()
 
-    name_dict = remote_hello_world_1("Bart")
-    name_str = remote_hello_world_2("Lisa")
+    params = ["Bart", "List", "Maggie"]
+    with concurrent.futures.ThreadPoolExecutor(3) as workers:
+        for result in workers.map(remote_hello_world_2, params):
+            LOGGER.info("name_dict: %s", result)
 
+    name_dict = remote_hello_world_1("Bart")
     LOGGER.info("name_dict: %s", name_dict)
-    LOGGER.info("name_str: %s", name_str)
+
+    # name_str = remote_hello_world_2("Lisa")
+    # LOGGER.info("name_str: %s", name_str)
 
 
 if __name__ == "__main__":

--- a/example/my_example/cli.py
+++ b/example/my_example/cli.py
@@ -7,8 +7,6 @@ from aws_codeseeder import BUNDLE_ROOT, LOGGER, codeseeder, services
 DEBUG_LOGGING_FORMAT = "[%(asctime)s][%(filename)-13s:%(lineno)3d] %(message)s"
 CLI_ROOT = os.path.dirname(os.path.abspath(__file__))
 
-_logger = logging.getLogger(__name__)
-
 
 def set_log_level(level: int, format: Optional[str] = None) -> None:
     """Helper function set LOG_LEVEL and optional log FORMAT
@@ -24,7 +22,7 @@ def set_log_level(level: int, format: Optional[str] = None) -> None:
     if format:
         kwargs["format"] = format  # type: ignore
     logging.basicConfig(**kwargs)  # type: ignore
-    _logger.setLevel(level)
+    LOGGER.setLevel(level=level)
 
     # Force loggers on dependencies to ERROR
     logging.getLogger("boto3").setLevel(logging.ERROR)
@@ -42,7 +40,7 @@ def print_results_callback(msg: str) -> None:
         Incoming log message
     """
     if msg.startswith("[RESULT] "):
-        _logger.info(msg)
+        LOGGER.info(msg)
 
 
 @codeseeder.configure("my-example", deploy_if_not_exists=True)
@@ -138,7 +136,7 @@ def deploy_test_stack() -> None:
         test_stack_exists, _ = services.cfn.does_stack_exist(stack_name=test_stack_name)
 
         if not test_stack_exists:
-            _logger.info("Deploying Test Stack")
+            LOGGER.info("Deploying Test Stack")
             template_filename = os.path.join(CLI_ROOT, "resources", "template.yaml")
             services.cfn.deploy_template(
                 stack_name=test_stack_name,
@@ -147,7 +145,7 @@ def deploy_test_stack() -> None:
                 parameters={"RoleName": stack_outputs["CodeBuildRole"]},
             )
         else:
-            _logger.info("Test Stack already exists")
+            LOGGER.info("Test Stack already exists")
 
 
 def main() -> None:
@@ -158,8 +156,8 @@ def main() -> None:
     name_dict = remote_hello_world_1("Bart")
     name_str = remote_hello_world_2("Lisa")
 
-    _logger.info("name_dict: %s", name_dict)
-    _logger.info("name_str: %s", name_str)
+    LOGGER.info("name_dict: %s", name_dict)
+    LOGGER.info("name_str: %s", name_str)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*  JIT deployment of the SeedKit Stack when `deploy_if_not_exists` is configured. This eliminates any calls to CloudFormation on decoration and will deploy the Stack only when a `remote_function` is actually executed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
