### PR TITLE
include the build id in phase log output for traceability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### New
 
 ### Changes
+- added build id to logging of codebuild phases
 
 ### Fixes
 

--- a/aws_codeseeder/services/codebuild.py
+++ b/aws_codeseeder/services/codebuild.py
@@ -240,7 +240,7 @@ def wait(build_id: str) -> Iterable[BuildInfo]:
         build = fetch_build_info(build_id=build_id)
 
         if build.current_phase is not last_phase or build.status is not last_status:
-            LOGGER.info("phase: %s (%s)", build.current_phase.value, build.status.value)
+            LOGGER.info("phase: %s %s (%s)", build.current_phase.value, build.build_id, build.status.value)
 
         yield build
 


### PR DESCRIPTION
*Issue #, if available:*

Added build id to log output when echoing the phase of the build


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
