### PR TITLE
Fixes awslabs/aws-codeseeder#16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+* Eliminate StackTrace message when Secret is not found
 
 ### Breaks
 

--- a/images/code-build-image/retrieve_docker_creds.py
+++ b/images/code-build-image/retrieve_docker_creds.py
@@ -23,7 +23,7 @@ def get_secret() -> Dict[str, Dict[str, str]]:
     try:
         get_secret_value_response = client.get_secret_value(SecretId=secret_name)
     except ClientError as e:
-        logger.exception(e)
+        logger.info("Secret with SecretId '%s' could not be retrieved from SecretsManager")
         return {}
     else:
         return cast(Dict[str, Dict[str, str]], json.loads(get_secret_value_response.get("SecretString", "{}")))


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-codeseeder/issues/16

*Description of changes:* Eliminate the full StackTrace when we fail to load Secrets from SecretsManager. In most cases this is confusing as a Secret is not always provided.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
