### PR TITLE
Feature/simplified seedkit deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ---
 
 ### New
+* simple check for whether a seedkit is deployed, the stack_name, and stack_outputs
+* simplified seedkit deployment for consumers
 * thread safe JIT Seedkit deployment
 
 ### Changes

--- a/aws_codeseeder/codeseeder.py
+++ b/aws_codeseeder/codeseeder.py
@@ -21,7 +21,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, cast
 from aws_codeseeder import LOGGER, __version__, _bundle, _classes, _remote
 from aws_codeseeder._classes import CodeSeederConfig, ConfigureDecorator, ModuleImporterEnum, RemoteFunctionDecorator
 from aws_codeseeder.commands import deploy_seedkit, seedkit_deployed
-from aws_codeseeder.services import cfn, codebuild
+from aws_codeseeder.services import codebuild
 
 __all__ = [
     "CodeSeederConfig",

--- a/aws_codeseeder/codeseeder.py
+++ b/aws_codeseeder/codeseeder.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, cast
 
 from aws_codeseeder import LOGGER, __version__, _bundle, _classes, _remote
 from aws_codeseeder._classes import CodeSeederConfig, ConfigureDecorator, ModuleImporterEnum, RemoteFunctionDecorator
-from aws_codeseeder.commands import deploy_seedkit
+from aws_codeseeder.commands import deploy_seedkit, seedkit_deployed
 from aws_codeseeder.services import cfn, codebuild
 
 __all__ = [
@@ -30,6 +30,8 @@ __all__ = [
     "RemoteFunctionDecorator",
     "configure",
     "remote_function",
+    "deploy_seedkit",
+    "seedkit_deployed",
 ]
 
 MODULE_IMPORTER = (
@@ -257,10 +259,9 @@ def remote_function(
                         file.write("export AWS_CODESEEDER_OUTPUT")
                 return result
             else:
-                stack_name = cfn.get_stack_name(seedkit_name=seedkit_name)
                 with registry_entry.lock:
                     while True:
-                        stack_exists, stack_outputs = cfn.does_stack_exist(stack_name=stack_name)
+                        stack_exists, stack_name, stack_outputs = seedkit_deployed(seedkit_name=seedkit_name)
                         if not stack_exists and registry_entry.deploy_if_not_exists:
                             deploy_seedkit(seedkit_name=seedkit_name)
                         elif not stack_exists:

--- a/aws_codeseeder/commands/__init__.py
+++ b/aws_codeseeder/commands/__init__.py
@@ -13,6 +13,6 @@
 #    limitations under the License.
 
 from aws_codeseeder.commands._module_commands import deploy_modules
-from aws_codeseeder.commands._seedkit_commands import deploy_seedkit, destroy_seedkit
+from aws_codeseeder.commands._seedkit_commands import deploy_seedkit, destroy_seedkit, seedkit_deployed
 
-__all__ = ["deploy_modules", "deploy_seedkit", "destroy_seedkit"]
+__all__ = ["deploy_modules", "deploy_seedkit", "destroy_seedkit", "seedkit_deployed"]

--- a/aws_codeseeder/commands/_module_commands.py
+++ b/aws_codeseeder/commands/_module_commands.py
@@ -18,6 +18,7 @@ import subprocess
 from typing import List
 
 from aws_codeseeder import CLI_ROOT, LOGGER, _bundle, create_output_dir
+from aws_codeseeder.codeseeder import seedkit_deployed
 from aws_codeseeder.services import cfn
 
 FILENAME = "update_repo.sh"
@@ -54,11 +55,10 @@ def deploy_modules(seedkit_name: str, python_modules: List[str]) -> None:
     ValueError
         If module names are of the wrong form
     """
-    stack_name: str = cfn.get_stack_name(seedkit_name=seedkit_name)
+    stack_exists, stack_name, stack_outputs = seedkit_deployed(seedkit_name=seedkit_name)
     LOGGER.info("Deploying Modules for Seedkit %s with Stack Name %s", seedkit_name, stack_name)
     LOGGER.debug("Python Modules: %s", python_modules)
 
-    stack_exists, stack_outputs = cfn.does_stack_exist(stack_name=stack_name)
     if not stack_exists:
         LOGGER.warn("Seedkit/Stack does not exist")
         return

--- a/aws_codeseeder/commands/_module_commands.py
+++ b/aws_codeseeder/commands/_module_commands.py
@@ -19,7 +19,6 @@ from typing import List
 
 from aws_codeseeder import CLI_ROOT, LOGGER, _bundle, create_output_dir
 from aws_codeseeder.codeseeder import seedkit_deployed
-from aws_codeseeder.services import cfn
 
 FILENAME = "update_repo.sh"
 RESOURCES_FILENAME = os.path.join(CLI_ROOT, "resources", FILENAME)

--- a/aws_codeseeder/commands/_seedkit_commands.py
+++ b/aws_codeseeder/commands/_seedkit_commands.py
@@ -27,12 +27,12 @@ def seedkit_deployed(seedkit_name: str) -> Tuple[bool, str, Dict[str, str]]:
     Parameters
     ----------
     seedkit_name : str
-        Namd of the seedkit to check.
+        Named of the seedkit to check.
 
     Returns
     -------
     Tuple[bool, str, Dict[str, str]]
-        Returns a Tuple with a bool indicating existence of the Stack, the Stack Name, and a dict with the
+        Returns a Tuple with a bool indicating existence of the Stack, the Stack name, and a dict with the
         Stack Outputs
     """
     stack_name: str = cfn.get_stack_name(seedkit_name=seedkit_name)

--- a/example/my_example/cli.py
+++ b/example/my_example/cli.py
@@ -3,7 +3,7 @@ import logging
 import os
 from typing import Dict, Optional
 
-from aws_codeseeder import BUNDLE_ROOT, LOGGER, codeseeder, services
+from aws_codeseeder import BUNDLE_ROOT, LOGGER, codeseeder, commands, services
 
 DEBUG_LOGGING_FORMAT = "[%(asctime)s][%(filename)-13s:%(lineno)3d] %(message)s"
 CLI_ROOT = os.path.dirname(os.path.abspath(__file__))
@@ -130,10 +130,9 @@ def deploy_test_stack() -> None:
     demonstrates how to use the Seedkit tools to create a dedicated IAM Role for use by CodeBuile. The example also
     attachs the Seedkit's IAM Managed Policy to this new Role, granting the Role access to the Seedkit's resources
     """
-    toolkit_stack_name = services.cfn.get_stack_name("my-example")
-    toolkit_stack_exists, stack_outputs = services.cfn.does_stack_exist(stack_name=toolkit_stack_name)
+    seedkit_deployed, stack_name, stack_outputs = commands.seedkit_deployed(seedkit_name="my-example")
 
-    if toolkit_stack_exists and not codeseeder.EXECUTING_REMOTELY:
+    if seedkit_deployed and not codeseeder.EXECUTING_REMOTELY:
         test_stack_name = "my-example-stack"
         test_stack_exists, _ = services.cfn.does_stack_exist(stack_name=test_stack_name)
 

--- a/images/code-build-image/retrieve_docker_creds.py
+++ b/images/code-build-image/retrieve_docker_creds.py
@@ -22,7 +22,7 @@ def get_secret() -> Dict[str, Dict[str, str]]:
 
     try:
         get_secret_value_response = client.get_secret_value(SecretId=secret_name)
-    except ClientError as e:
+    except ClientError:
         logger.info("Secret with SecretId '%s' could not be retrieved from SecretsManager")
         return {}
     else:


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-codeseeder/issues/20

*Description of changes:* Simplify checking for and deploying the Seedkit for consumers. 

Enables checking for existence of the seedkit as well as returning the `stack_name` and `stack_outputs` if it is deployed:

```
from aws_codeseeder import commands

deployed, stack_name, stack_outputs = commands.seedkit_deployed(seedkit_name="some-name")

if not deployed:
    commands.deploy_seedkit(seedkit_name="some-name")
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
