### PR TITLE
Fix helm install problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Breaks
 
+## 0.4.1 - (unreleased)
+---
+
+### New
+
+### Changes
+
+### Fixes
+- fixed helm tool not installing. specifiying version prevents getting from the actively developed main
+### Breaks
 
 ## 0.4.0 - (2022-08-16)
 ---

--- a/images/code-build-image/Dockerfile
+++ b/images/code-build-image/Dockerfile
@@ -17,6 +17,7 @@
 FROM aws/codebuild/standard
 
 ARG BOTO_VERSION=1.21.37
+ARG HELM_VERSION=0.13.0
 
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
     apt-get -y install nodejs
@@ -40,7 +41,7 @@ RUN curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/
 # Install Helm tools
 RUN curl -sSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash && \
     helm version --short && \
-    helm plugin install https://github.com/hypnoglow/helm-s3.git && \
+    helm plugin install https://github.com/hypnoglow/helm-s3.git --version $HELM_VERSION && \
     helm repo add stable https://charts.helm.sh/stable
 
 RUN npm install -g yarn


### PR DESCRIPTION
*Issue #, if available:*
codebuild image has been failing. Some of the log:

`Step 7/12 : RUN curl -sSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash &&     helm version --short &&     helm plugin install https://github.com/hypnoglow/helm-s3.git &&     helm repo add stable https://charts.helm.sh/stable
 ---> Running in 7220dc1d01fc
Downloading https://get.helm.sh/helm-v3.9.3-linux-amd64.tar.gz
Verifying checksum... Done.
Preparing to install helm into /usr/local/bin
helm installed into /usr/local/bin/helm
v3.9.3+g414ff28
Downloading and installing helm-s3 v0.13.0 ...
Checksum is valid.
mv: cannot stat 'releases/v0.13.0/bin/helm-s3': No such file or directory
helm-s3 install hook failed. Please remove the plugin using 'helm plugin remove s3' and install again.
Error: plugin install hook for "s3" exited with error`




*Description of changes:*
Fixed issue by specifying the release version in the `helm plugin install` command.

According to the owner of helm-s3, specifying the version is the recommended approach when installing helm-s3 as main is actively developed.

https://github.com/hypnoglow/helm-s3/issues/203 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
