### PR TITLE
enable support for all CodeBuild env_var types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+* Missing support for PARAMETER_STORE and SECRETS_MANAGER env_vars in CodeBuild
 
 ### Breaks
 

--- a/aws_codeseeder/__init__.py
+++ b/aws_codeseeder/__init__.py
@@ -18,7 +18,10 @@ import shutil
 
 import pkg_resources
 
-from aws_codeseeder.__metadata__ import __description__, __license__, __title__  # noqa: F401
+from aws_codeseeder.__metadata__ import __description__, __license__, __title__
+from aws_codeseeder._classes import EnvVar, EnvVarType
+
+__all__ = ["EnvVar", "EnvVarType"]
 
 __version__: str = pkg_resources.get_distribution(__title__).version
 
@@ -27,6 +30,18 @@ CLI_ROOT = os.path.dirname(os.path.abspath(__file__))
 BUNDLE_ROOT = os.path.abspath(
     os.path.join(os.environ.get("CODEBUILD_SRC_DIR", os.path.join(os.getcwd(), "codeseeder.out")), "bundle")
 )
+
+__all__ = [
+    "__description__",
+    "__license__",
+    "__title__",
+    "__version__",
+    "EnvVar",
+    "EnvVarType",
+    "LOGGER",
+    "CLI_ROOT",
+    "BUNDLE_ROOT",
+]
 
 
 def create_output_dir(name: str) -> str:

--- a/example/my_example/cli.py
+++ b/example/my_example/cli.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 
 from boto3 import Session
 
-from aws_codeseeder import BUNDLE_ROOT, LOGGER, codeseeder, commands, services
+from aws_codeseeder import BUNDLE_ROOT, LOGGER, EnvVar, codeseeder, commands, services
 
 DEBUG_LOGGING_FORMAT = "[%(asctime)s][%(filename)-13s:%(lineno)3d] %(message)s"
 CLI_ROOT = os.path.dirname(os.path.abspath(__file__))
@@ -134,6 +134,12 @@ def remote_hello_world_2(name: str) -> str:
         extra_exported_env_vars=["ANOTHER_EXPORTED_VAR"],
         bundle_id=name,
         boto3_session=session,
+        extra_env_vars={
+            "OTHER_KEY_1": "key1",
+            "OTHER_KEY_2": EnvVar(value="PlainText"),
+            # "OTHER_KEY_3": EnvVar(value="ParameterStoreValue", type=EnvVarType.PARAMETER_STORE),
+            # "OTHER_KEY_4": EnvVar(value="SecretsManagerValue", type=EnvVarType.SECRETS_MANAGER),
+        },
     )
     def remote_hello_world_2(name: str) -> str:
         print(f"[RESULT] {name}")


### PR DESCRIPTION
*Issue #, if available:* closes #43

*Description of changes:*
- enable support for all CodeBuild env_var types 
- maintains backwards compatibility with existing env_var specification

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
