### PR TITLE
deploy_seedkit thread safety fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+* deploy_seedkit is not threadsafe due to reuse of seedkit/ output directory
 * Missing support for PARAMETER_STORE and SECRETS_MANAGER env_vars in CodeBuild
 
 ### Breaks

--- a/aws_codeseeder/_cfn_seedkit.py
+++ b/aws_codeseeder/_cfn_seedkit.py
@@ -38,7 +38,8 @@ def synth(
     deploy_codeartifact: bool = False,
     session: Optional[Session] = None,
 ) -> str:
-    out_dir = create_output_dir("seedkit")
+    deploy_id = deploy_id if deploy_id else "".join(random.choice(string.ascii_lowercase) for i in range(6))
+    out_dir = create_output_dir(f"seedkit-{deploy_id}")
     output_filename = os.path.join(out_dir, FILENAME)
 
     LOGGER.debug("Reading %s", RESOURCES_FILENAME)
@@ -64,7 +65,7 @@ def synth(
                 seedkit_name=seedkit_name,
                 account_id=get_account_id(session=session),
                 region=get_region(session=session),
-                deploy_id=deploy_id if deploy_id else "".join(random.choice(string.ascii_lowercase) for i in range(6)),
+                deploy_id=deploy_id,
                 role_prefix="/",
             )
         )


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- reuse deploy_id in order to ensure unique output directory and enable multiple, threaded seedkit deployments

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
