### PR TITLE
fix: extra_files failed to create dest subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ---
 
 ### New
+- added `pre_execution_commands` and `extra_pre_execution_commands` to enable commands in the Build phase prior to
+  `remote_function execution`
 
 ### Changes
 
 ### Fixes
 - adding support for Windows OS based deployments when bundling resources
+- `files` and `extra_files` failed to create subdirectories in bundles if keys contained director paths
 
 ### Breaks
 

--- a/aws_codeseeder/__init__.py
+++ b/aws_codeseeder/__init__.py
@@ -15,7 +15,7 @@
 import logging
 import os
 import shutil
-from typing import MutableSet
+from typing import MutableSet, Optional
 
 import pkg_resources
 
@@ -93,3 +93,28 @@ def create_output_dir(name: str) -> str:
         pass
     os.makedirs(out_dir, exist_ok=True)
     return out_dir
+
+
+def get_logger(level: int, format: Optional[str] = None) -> logging.Logger:
+    """Helper function set LOG_LEVEL and optional log FORMAT
+
+    Parameters
+    ----------
+    level : int
+        logger.LOG_LEVEL
+    format : Optional[str], optional
+        Optional string format to apply to log lines, by default None
+    """
+    kwargs = {"level": level}
+    if format:
+        kwargs["format"] = format  # type: ignore
+    logging.basicConfig(**kwargs)  # type: ignore
+    LOGGER.setLevel(level=level)
+
+    # Force loggers on dependencies to ERROR
+    logging.getLogger("boto3").setLevel(logging.ERROR)
+    logging.getLogger("botocore").setLevel(logging.ERROR)
+    logging.getLogger("s3transfer").setLevel(logging.ERROR)
+    logging.getLogger("urllib3").setLevel(logging.ERROR)
+
+    return LOGGER

--- a/aws_codeseeder/_bundle.py
+++ b/aws_codeseeder/_bundle.py
@@ -129,7 +129,10 @@ def generate_bundle(
     if files is not None:
         for src_file, name in files:
             LOGGER.debug(f"***file={src_file}:name={name}")
-            shutil.copy(src=src_file, dst=os.path.realpath(os.path.join(bundle_dir, name)))
+            dst_file = os.path.realpath(os.path.join(bundle_dir, name))
+            if "/" in name:
+                os.makedirs(os.path.dirname(dst_file), exist_ok=True)
+            shutil.copy(src=src_file, dst=dst_file)
 
     LOGGER.debug("bundle_dir: %s", bundle_dir)
 

--- a/aws_codeseeder/_classes.py
+++ b/aws_codeseeder/_classes.py
@@ -116,8 +116,12 @@ class CodeSeederConfig:
         Commands to execute during the Install phase of the CodeBuild execution, by default None
     pre_build_commands : Optional[List[str]], optional
         Commands to execute during the PreBuild phase of the CodeBuild execution, by default None
+    pre_execution_commands : Optional[List[str]], optional
+        Commands to execute during the Build phase of the CodeBuild execution prior to calling the remote_function,
+        by default None
     build_commands : Optional[List[str]], optional
-        Commands to execute during the Build phase of the CodeBuild execution, by default None
+        Commands to execute during the Build phase of the CodeBuild execution after calling the remote_functin,
+        by default None
     post_build_commands : Optional[List[str]], optional
         Commands to execute during the PostBuild phase of the CodeBuild execution, by default None
     dirs : Optional[Dict[str, str]], optional
@@ -145,6 +149,7 @@ class CodeSeederConfig:
     codebuild_compute_type: Optional[str] = None
     install_commands: Optional[List[str]] = cast(List[str], dataclasses.field(default_factory=list))
     pre_build_commands: Optional[List[str]] = cast(List[str], dataclasses.field(default_factory=list))
+    pre_execution_commands: Optional[List[str]] = cast(List[str], dataclasses.field(default_factory=list))
     build_commands: Optional[List[str]] = cast(List[str], dataclasses.field(default_factory=list))
     post_build_commands: Optional[List[str]] = cast(List[str], dataclasses.field(default_factory=list))
     dirs: Optional[Dict[str, str]] = cast(Dict[str, str], dataclasses.field(default_factory=dict))

--- a/aws_codeseeder/codeseeder.py
+++ b/aws_codeseeder/codeseeder.py
@@ -99,6 +99,7 @@ def remote_function(
     codebuild_compute_type: Optional[str] = None,
     extra_install_commands: Optional[List[str]] = None,
     extra_pre_build_commands: Optional[List[str]] = None,
+    extra_pre_execution_commands: Optional[List[str]] = None,
     extra_build_commands: Optional[List[str]] = None,
     extra_post_build_commands: Optional[List[str]] = None,
     extra_dirs: Optional[Dict[str, str]] = None,
@@ -147,8 +148,12 @@ def remote_function(
         Additional commands to execute during the Install phase of the CodeBuild execution, by default None
     extra_pre_build_commands : Optional[List[str]], optional
         Additional commands to execute during the PreBuild phase of the CodeBuild execution, by default None
+    extra_pre_execution_commands : Optional[List[str]], optional
+        Additional commands to execute during the Build phase of the CodeBuild execution prior to calling the
+        remote_function, by default None
     extra_build_commands : Optional[List[str]], optional
-        Additional commands to execute during the Build phase of the CodeBuild execution, by default None
+        Additional commands to execute during the Build phase of the CodeBuild execution after calling the
+        remote_function, by default None
     extra_post_build_commands : Optional[List[str]], optional
         Additional commands to execute during the PostBuild phase of the CodeBuild execution, by default None
     extra_dirs : Optional[Dict[str, str]], optional
@@ -194,6 +199,7 @@ def remote_function(
         codebuild_compute_type = decorator.codebuild_compute_type  # type: ignore
         install_commands = decorator.install_commands  # type: ignore
         pre_build_commands = decorator.pre_build_commands  # type: ignore
+        pre_execution_commands = decorator.pre_execution_commands  # type: ignore
         build_commands = decorator.build_commands  # type: ignore
         post_build_commands = decorator.post_build_commands  # type: ignore
         dirs = decorator.dirs  # type: ignore
@@ -226,6 +232,7 @@ def remote_function(
         )
         install_commands = config_object.install_commands + install_commands
         pre_build_commands = config_object.pre_build_commands + pre_build_commands
+        pre_execution_commands = config_object.pre_execution_commands + pre_execution_commands
         build_commands = config_object.build_commands + build_commands
         post_build_commands = config_object.post_build_commands + post_build_commands
         dirs = {**cast(Mapping[str, str], config_object.dirs), **dirs}
@@ -326,6 +333,9 @@ def remote_function(
                     cmds_build=[
                         ". ~/.venv/bin/activate",
                         "cd ${CODEBUILD_SRC_DIR}/bundle",
+                    ]
+                    + pre_execution_commands
+                    + [
                         "codeseeder execute --args-file fn_args.json --debug",
                         (
                             f"if [[ -f {RESULT_EXPORT_FILE} ]]; then source {RESULT_EXPORT_FILE}; "
@@ -396,6 +406,9 @@ def remote_function(
     decorator.codebuild_compute_type = codebuild_compute_type  # type: ignore
     decorator.install_commands = [] if extra_install_commands is None else extra_install_commands  # type: ignore
     decorator.pre_build_commands = [] if extra_pre_build_commands is None else extra_pre_build_commands  # type: ignore
+    decorator.pre_execution_commands = (  # type: ignore
+        [] if extra_pre_execution_commands is None else extra_pre_execution_commands
+    )
     decorator.build_commands = [] if extra_build_commands is None else extra_build_commands  # type: ignore
     decorator.post_build_commands = (  # type: ignore
         [] if extra_post_build_commands is None else extra_post_build_commands


### PR DESCRIPTION
*Issue #, if available:* Fixes: #88

*Description of changes:*
- fix: `files` and `extra_files` failed to create destination subdirectories
- new: `pre_execution_commands` and `extra_pre_execution_commands` to enable commands in the Build phase prior to `remote_function` execution


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
