### PR TITLE
updating build image version, adding docker login to bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### New
 
 ### Changes
-
+- modifed default version of codebuild image to `aws/codebuild/standard:6.0`
+- moved `retrieve_docker_creds.py` to be a resource in the codebase and into the bundle
 ### Fixes
 
 ### Breaks

--- a/aws_codeseeder/_bundle.py
+++ b/aws_codeseeder/_bundle.py
@@ -119,6 +119,12 @@ def generate_bundle(
     with open(fn_args_file, "w") as file:
         file.write(json.dumps(fn_args))
 
+    # Add the docker login script
+    shutil.copy(
+        src=os.path.join(os.path.dirname(os.path.abspath(__file__)), "resources/retrieve_docker_creds.py"),
+        dst=os.path.join(bundle_dir, "retrieve_docker_creds.py"),
+    )
+
     LOGGER.debug(f"generate_bundle dirs={dirs}")
     # Extra Directories
     if dirs is not None:

--- a/aws_codeseeder/resources/retrieve_docker_creds.py
+++ b/aws_codeseeder/resources/retrieve_docker_creds.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+import json
+import logging
+import os
+import subprocess
+from typing import Dict, cast
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def get_secret() -> Dict[str, Dict[str, str]]:
+    secret_name = os.environ.get("AWS_CODESEEDER_DOCKER_SECRET", "NO_SECRET")
+    region_name = os.environ.get("AWS_DEFAULT_REGION")
+
+    session = boto3.session.Session()
+    client = session.client(service_name="secretsmanager", region_name=region_name)
+
+    try:
+        get_secret_value_response = client.get_secret_value(SecretId=secret_name)
+    except ClientError:
+        logger.info("Secret with SecretId '%s' could not be retrieved from SecretsManager")
+        return {}
+    else:
+        return cast(Dict[str, Dict[str, str]], json.loads(get_secret_value_response.get("SecretString", "{}")))
+
+
+if __name__ == "__main__":
+    credentials = get_secret()
+    for registry, creds in credentials.items():
+        username = creds["username"]
+        password = creds["password"]
+        subprocess.call(
+            f"docker login --username {username} --password '{password}' {registry}",
+            shell=True,
+        )

--- a/aws_codeseeder/resources/template.yaml
+++ b/aws_codeseeder/resources/template.yaml
@@ -203,7 +203,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:4.0
+        Image: aws/codebuild/standard:6.0
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value:

--- a/aws_codeseeder/services/codebuild.py
+++ b/aws_codeseeder/services/codebuild.py
@@ -312,6 +312,8 @@ def generate_spec(
     exported_variables: List[str] = [] if exported_env_vars is None else exported_env_vars
     exported_variables.append("AWS_CODESEEDER_OUTPUT")
     install = [
+        "mkdir /var/scripts/",
+        "mv $CODEBUILD_SRC_DIR/bundle/retrieve_docker_creds.py /var/scripts/retrieve_docker_creds.py || true",
         "/var/scripts/retrieve_docker_creds.py && echo 'Docker logins successful' || echo 'Docker logins failed'",
     ]
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update the default build version to `aws/codebuild/standard:6.0`
- include the `resources/retrieve_docker_creds.py` script in the bundle, invoke it after moving it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
