### PR TITLE
allow code to fail gracefully if dir exists for docker-login process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - allow the execution of docker login process to fail gracefully if the dir exists
 
 ### Breaks
+
+
 ## 0.9.0 - (2023-05-02)
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Changelog](http://keepachangelog.com/).
 
 
+## Unreleased
+---
 
+### New
+
+### Changes
+
+### Fixes
+- allow the execution of docker login process to fail gracefully if the dir exists
+
+### Breaks
 ## 0.9.0 - (2023-05-02)
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Fixes
 - allow the execution of docker login process to fail gracefully if the dir exists
+- remove configuration of python and node runtimes by default
 
 ### Breaks
 

--- a/aws_codeseeder/_classes.py
+++ b/aws_codeseeder/_classes.py
@@ -159,9 +159,7 @@ class CodeSeederConfig:
     )
     exported_env_vars: Optional[List[str]] = cast(List[str], dataclasses.field(default_factory=list))
     abort_phases_on_failure: bool = True
-    runtime_versions: Optional[Dict[str, str]] = dataclasses.field(
-        default_factory=lambda: {"python": "3.7", "nodejs": "12", "docker": "19"}
-    )
+    runtime_versions: Optional[Dict[str, str]] = None
 
 
 ConfigureFn = Callable[[NamedArg(CodeSeederConfig, "configuration")], None]  # noqa: F821

--- a/aws_codeseeder/services/codebuild.py
+++ b/aws_codeseeder/services/codebuild.py
@@ -312,7 +312,7 @@ def generate_spec(
     exported_variables: List[str] = [] if exported_env_vars is None else exported_env_vars
     exported_variables.append("AWS_CODESEEDER_OUTPUT")
     install = [
-        "mkdir /var/scripts/",
+        "mkdir -p /var/scripts/",
         "mv $CODEBUILD_SRC_DIR/bundle/retrieve_docker_creds.py /var/scripts/retrieve_docker_creds.py || true",
         "/var/scripts/retrieve_docker_creds.py && echo 'Docker logins successful' || echo 'Docker logins failed'",
     ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since adding the docker login script to the bundle and copying to local filesystem, we need to gracefully fail if the `/var/scripts` dir already exists...this corrects that error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
