### PR TITLE
fix: incompatibility with updated dataclass in python 3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+- incompatibility with updated `dataclass` in python 3.11
 
 ### Breaks
 

--- a/aws_codeseeder/_classes.py
+++ b/aws_codeseeder/_classes.py
@@ -159,7 +159,7 @@ class CodeSeederConfig:
     )
     exported_env_vars: Optional[List[str]] = cast(List[str], dataclasses.field(default_factory=list))
     abort_phases_on_failure: bool = True
-    runtime_versions: Optional[Dict[str, str]] = None
+    runtime_versions: Optional[Dict[str, str]] = cast(Dict[str, str], dataclasses.field(default_factory=dict))
 
 
 ConfigureFn = Callable[[NamedArg(CodeSeederConfig, "configuration")], None]  # noqa: F821
@@ -173,7 +173,7 @@ RemoteFunctionDecorator = Callable[..., RemoteFunctionFn]
 class RegistryEntry:
     configured: bool = False
     config_function: Optional[ConfigureFn] = None
-    config_object: CodeSeederConfig = CodeSeederConfig()
+    config_object: CodeSeederConfig = dataclasses.field(default_factory=CodeSeederConfig)
     stack_outputs: Optional[Dict[str, str]] = None
     remote_functions: Dict[str, RemoteFunctionFn] = dataclasses.field(default_factory=dict)
     deploy_if_not_exists: bool = False

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     license=about["__license__"],
     packages=find_packages(include=["aws_codeseeder", "aws_codeseeder.*"]),
     keywords=["aws", "cdk"],
-    python_requires=">=3.7",
+    python_requires=">=3.7, <=3.12",
     install_requires=[
         "boto3>=1.19.0",
         "pyyaml>=5.4",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     license=about["__license__"],
     packages=find_packages(include=["aws_codeseeder", "aws_codeseeder.*"]),
     keywords=["aws", "cdk"],
-    python_requires=">=3.7, <=3.12",
+    python_requires=">=3.7, <3.12",
     install_requires=[
         "boto3>=1.19.0",
         "pyyaml>=5.4",


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
- fixed incompatibility with updated `dataclass` in python 3.11. `config_object` was previously allowed to be mutable, now uses a dataclass factory


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
