### PR TITLE
add stack status to deployed cfn stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### New
 
 ### Changes
-
+- add the `StackStatus` to the Outputs when checking in `cfn.does_stack_exist` - the stack may exist and not be completed
+  
 ### Fixes
 
 ### Breaks

--- a/aws_codeseeder/services/cfn.py
+++ b/aws_codeseeder/services/cfn.py
@@ -174,7 +174,9 @@ def does_stack_exist(
         if len(resp["Stacks"]) < 1:
             return (False, {})
         else:
-            return (True, {o["OutputKey"]: o["OutputValue"] for o in resp["Stacks"][0].get("Outputs", [])})
+            output = {o["OutputKey"]: o["OutputValue"] for o in resp["Stacks"][0].get("Outputs", [])}
+            output["StackStatus"] = resp["Stacks"][0].get("StackStatus", None)
+            return (True, output)
     except botocore.exceptions.ClientError as ex:
         error: Dict[str, Any] = ex.response["Error"]
         if error["Code"] == "ValidationError" and f"Stack with id {stack_name} does not exist" in error["Message"]:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When checking the outputs of a CFN stack, add the StackStatus.  When a template is is being created or updated, it will exist but not have any outputs, indicating a failure

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
