### PR TITLE
feat: Add logic to set image pull credentials correctly for aws curated images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### New
 
 ### Changes
-  
+- Allows override of codeseeder build image with aws curated images.
+- Updates codeseeder seedkit cloudformation template with a parameter `BuildImage``. This can be used in the future as an input for default image set in the seedkit and referenced as necessary.
+
 ### Fixes
 
 ### Breaks

--- a/aws_codeseeder/resources/template.yaml
+++ b/aws_codeseeder/resources/template.yaml
@@ -1,6 +1,10 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: |
   AWS CodeSeeder - codeseeder-${seedkit_name}
+Parameters:
+  BuildImage:
+    Type: String
+    Default: aws/codebuild/standard:6.0
 Resources:
   Bucket:
     Type: AWS::S3::Bucket
@@ -203,7 +207,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:6.0
+        Image: !Ref BuildImage
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value:
@@ -347,6 +351,11 @@ Outputs:
         - Arn
     Export:
       Name: codeseeder-${seedkit_name}-codebuild-project-arn
+  
+  CodeBuildProjectBuildImage:
+    Value: !Ref BuildImage
+    Export:
+      Name: codeseeder-${seedkit_name}-codebuild-project-build-image
 
   CodeArtifactDomain:
     Value:

--- a/aws_codeseeder/services/codebuild.py
+++ b/aws_codeseeder/services/codebuild.py
@@ -127,8 +127,12 @@ def start(
         The CodeBuild Build/Exectuion Id
     """
     client = boto3_client("codebuild", session=session)
-    credentials: Optional[str] = "SERVICE_ROLE" if overrides and overrides.get("imageOverride", None) else None
-    LOGGER.debug("Credentials: %s", credentials)
+    image_override = overrides.get("imageOverride", None)
+    if image_override.startswith('aws/'):
+        image_pull_credentials: Optional[str] = "CODEBUILD"
+    else:
+        image_pull_credentials: Optional[str] = "SERVICE_ROLE" if image_override else None
+    LOGGER.debug("Image Pull Credentials: %s", image_pull_credentials)
     LOGGER.debug("Overrides: %s", overrides)
     build_params = {
         "projectName": project_name,
@@ -146,8 +150,8 @@ def start(
             "s3Logs": {"status": "DISABLED"},
         },
     }
-    if credentials:
-        build_params["imagePullCredentialsTypeOverride"] = credentials
+    if image_pull_credentials:
+        build_params["imagePullCredentialsTypeOverride"] = image_pull_credentials
 
     if overrides:
         build_params = {**build_params, **overrides}

--- a/aws_codeseeder/services/codebuild.py
+++ b/aws_codeseeder/services/codebuild.py
@@ -127,10 +127,10 @@ def start(
         The CodeBuild Build/Exectuion Id
     """
     client = boto3_client("codebuild", session=session)
-    image_override: Optional[str] = overrides.get("imageOverride", None)
+    image_override: Optional[str] = overrides.get("imageOverride", None) if overrides else None
     image_pull_credentials: Optional[str] = None
     if image_override:
-        if image_override.startswith('aws/'):
+        if image_override.startswith("aws/"):
             image_pull_credentials = "CODEBUILD"
         else:
             image_pull_credentials = "SERVICE_ROLE"

--- a/aws_codeseeder/services/codebuild.py
+++ b/aws_codeseeder/services/codebuild.py
@@ -128,11 +128,15 @@ def start(
     """
     client = boto3_client("codebuild", session=session)
     image_override = overrides.get("imageOverride", None)
-    if image_override.startswith('aws/'):
-        image_pull_credentials: Optional[str] = "CODEBUILD"
-    else:
-        image_pull_credentials: Optional[str] = "SERVICE_ROLE" if image_override else None
-    LOGGER.debug("Image Pull Credentials: %s", image_pull_credentials)
+    if image_override:
+        if image_override.startswith('aws/'):
+            image_pull_credentials: Optional[str] = "CODEBUILD"
+        else:
+            image_pull_credentials: Optional[str] = "SERVICE_ROLE"
+            LOGGER.debug("Image Pull Credentials: %s", image_pull_credentials)
+    else: 
+        image_pull_credentials: Optional[str] = None
+
     LOGGER.debug("Overrides: %s", overrides)
     build_params = {
         "projectName": project_name,

--- a/aws_codeseeder/services/codebuild.py
+++ b/aws_codeseeder/services/codebuild.py
@@ -127,15 +127,14 @@ def start(
         The CodeBuild Build/Exectuion Id
     """
     client = boto3_client("codebuild", session=session)
-    image_override = overrides.get("imageOverride", None)
+    image_override: Optional[str] = overrides.get("imageOverride", None)
+    image_pull_credentials: Optional[str] = None
     if image_override:
         if image_override.startswith('aws/'):
-            image_pull_credentials: Optional[str] = "CODEBUILD"
+            image_pull_credentials = "CODEBUILD"
         else:
-            image_pull_credentials: Optional[str] = "SERVICE_ROLE"
+            image_pull_credentials = "SERVICE_ROLE"
             LOGGER.debug("Image Pull Credentials: %s", image_pull_credentials)
-    else: 
-        image_pull_credentials: Optional[str] = None
 
     LOGGER.debug("Overrides: %s", overrides)
     build_params = {


### PR DESCRIPTION
**Description of Changes**
- Allows override of codeseeder build image with aws curated images. 
```yaml
name: buckets
path: git::https://github.com/awslabs/idf-modules.git//modules/storage/buckets/?ref=release/1.2.0&depth=1
codebuildImage: 'aws/codebuild/standard:7.0'
parameters:
  - name: encryption-type
    value: SSE
```
- Updates codeseeder seedkit cloudformation template with a parameter `BuildImage`. This can be used in the future as an input for default image set in the seedkit and referenced as necessary.

**Issue #, if available:**
Indirectly related to: [[FEATURE] Support CodeBuild runtime-versions in module deployspecs](https://github.com/awslabs/seed-farmer/issues/467)


**Testing**
Template example deployed with test build.
<img width="1019" alt="Screenshot 2024-01-04 at 12 38 42 PM" src="https://github.com/awslabs/aws-codeseeder/assets/6465221/3a91c14f-9453-4a2e-8937-fda5f5d7007f">

Build run with overridden curated image successfully.
<img width="336" alt="Screenshot 2024-01-04 at 12 40 07 PM" src="https://github.com/awslabs/aws-codeseeder/assets/6465221/37278ff2-e9b5-470c-b80f-dc4de98e34eb">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
