### PR TITLE
updating default codebuild iamge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### New
 
 ### Changes
+- updating the default codebuild image to `aws/codebuild/standard:7.0`
 
 ### Fixes
 

--- a/aws_codeseeder/resources/template.yaml
+++ b/aws_codeseeder/resources/template.yaml
@@ -4,7 +4,7 @@ Description: |
 Parameters:
   BuildImage:
     Type: String
-    Default: aws/codebuild/standard:6.0
+    Default: aws/codebuild/standard:7.0
 Resources:
   Bucket:
     Type: AWS::S3::Bucket


### PR DESCRIPTION
*Issue #, if available:*
#154 
*Description of changes:*
Update the default version of the build image to `aws/codebuild/standard:7.0`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
