### PR TITLE
feat: support env parameter `ENDPOINT_URL` to helps locate the specif…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -379,3 +379,7 @@ cdk.json
 
 # codeseeder
 codeseeder.out
+
+# npm pacakge
+package-lock.json
+package.json

--- a/aws_codeseeder/services/_utils.py
+++ b/aws_codeseeder/services/_utils.py
@@ -24,7 +24,7 @@ from aws_codeseeder import LOGGER, __version__, _classes
 
 _session_singleton: _classes.SessionSingleton = _classes.SessionSingleton()
 
-_endpoint_url =  os.getenv('ENV_VARIABLE_NAME')
+_endpoint_url =  os.getenv('ENDPOINT_URL')
 
 
 def _get_botocore_config() -> botocore.config.Config:

--- a/aws_codeseeder/services/_utils.py
+++ b/aws_codeseeder/services/_utils.py
@@ -18,10 +18,13 @@ from typing import Any, Callable, Optional, Tuple, Union, cast
 
 import boto3
 import botocore
+import os
 
 from aws_codeseeder import LOGGER, __version__, _classes
 
 _session_singleton: _classes.SessionSingleton = _classes.SessionSingleton()
+
+_endpoint_url =  os.getenv('ENV_VARIABLE_NAME')
 
 
 def _get_botocore_config() -> botocore.config.Config:
@@ -42,7 +45,10 @@ def boto3_client(
         session = session()
 
     session = cast(boto3.Session, session)
-    return session.client(service_name=service_name, use_ssl=True, config=_get_botocore_config())
+    if not _endpoint_url:
+        return session.client(service_name=service_name, use_ssl=True, config=_get_botocore_config(), endpoint_url=_endpoint_url)
+    else:
+        return session.client(service_name=service_name, use_ssl=True, config=_get_botocore_config(), endpoint_url=_endpoint_url)
 
 
 def boto3_resource(

--- a/aws_codeseeder/services/cfn.py
+++ b/aws_codeseeder/services/cfn.py
@@ -174,7 +174,7 @@ def does_stack_exist(
         if len(resp["Stacks"]) < 1:
             return (False, {})
         else:
-            output = {o["OutputKey"]: o["OutputValue"] for o in resp["Stacks"][0].get("Outputs", [])}
+            output = {o["OutputKey"]: o.get("OutputValue", o.get("ExportName")) for o in resp["Stacks"][0].get("Outputs", [])}
             output["StackStatus"] = resp["Stacks"][0].get("StackStatus", None)
             return (True, output)
     except botocore.exceptions.ClientError as ex:


### PR DESCRIPTION
…ic AWS service (e.g.localstack)

*Issue #, if available:*

*Description of changes:*
When integrating with localstack, it reports that the security token included in the request is invalid. The reason is that the profile was not successfully passed when creating the session somewhere. The easiest way to modify it is to specify the endpoint through environment variables when creating boto3 client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
