### PR TITLE
chore: change logging for npm_mirror_support script

### DIFF
--- a/aws_codeseeder/resources/npm_mirror_support.py
+++ b/aws_codeseeder/resources/npm_mirror_support.py
@@ -39,6 +39,7 @@ def main(url: str) -> None:
         creds = get_secret(secret_name=secret_name_key)
         if key in creds.keys():
             ssl_token = creds[key]["ssl_token"] if creds[key].get("ssl_token") else None
+            print("Secret configured for npm auth")
             subprocess.call(["npm", "config", "set", f"{url.replace('https:', '')}:_auth={ssl_token}"])
     else:
         print("'AWS_CODESEEDER_NPM_MIRROR_SECRET' is not set")

--- a/aws_codeseeder/resources/npm_mirror_support.py
+++ b/aws_codeseeder/resources/npm_mirror_support.py
@@ -40,9 +40,9 @@ def main(url: str) -> None:
         if key in creds.keys():
             ssl_token = creds[key]["ssl_token"] if creds[key].get("ssl_token") else None
             subprocess.call(["npm", "config", "set", f"{url.replace('https:', '')}:_auth={ssl_token}"])
-        logger.info("Calling npm config with %s", url)
     else:
-        logger.info("'AWS_CODESEEDER_NPM_MIRROR_SECRET' is not set")
+        print("'AWS_CODESEEDER_NPM_MIRROR_SECRET' is not set")
+    print(f"Calling npm config with {url}")
     subprocess.call(["npm", "config", "set", "registry", url])
 
 


### PR DESCRIPTION
### Closes: https://github.com/awslabs/seed-farmer/issues/702

### Changes
- change logging for npm_mirror_support script

### New Output 
```bash
# With Secret
> python aws_codeseeder/resources/npm_mirror_support.py https://mynpmmirror.com
Secret configured for npm auth
Calling npm config with https://mynpmmirror.com

# No Secret
> python aws_codeseeder/resources/npm_mirror_support.py https://mynpmmirror.com
'AWS_CODESEEDER_NPM_MIRROR_SECRET' is not set
Calling npm config with https://mynpmmirror.com
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
