### PR TITLE
add action to ensure documentation can build

### DIFF
--- a/.github/workflows/check-documentation-build.yml
+++ b/.github/workflows/check-documentation-build.yml
@@ -1,0 +1,56 @@
+name: Documentation Check
+
+on:
+  push:
+    branches: 
+      - "main"
+    paths:
+      - "docs/**"
+      - ".readthedocs.yaml"
+      - "setup.py"
+      - "VERSION"
+      - ".github/workflows/check-documentation-build.yml"
+
+  pull_request:
+    branches:
+      - "main"
+      - "stable"
+    paths:
+      - "docs/**"
+      - ".readthedocs.yaml"
+      - "setup.py"
+      - "VERSION"
+      - ".github/workflows/check-documentation-build.yml"
+  
+  # Allows this workflow to be run manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install yq
+        run: sudo snap install yq
+      - name: Get Python Version
+        id: get-version
+        run: |
+            python_version=$(cat .readthedocs.yaml | yq ".build.tools.python")
+            echo python-version=$python_version >> $GITHUB_OUTPUT
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '${{ steps.get-version.outputs.python-version }}'
+      - name: Update pip
+        run: pip install --upgrade pip
+      - name: Install Requirements for building docs
+        run: pip install -r docs/requirements-docs.txt
+      - name: Install SeedFarmer
+        run: pip install -e .
+      - name: Sphinx Build
+        working-directory: ./docs/
+        run: make html

--- a/.github/workflows/check-documentation-build.yml
+++ b/.github/workflows/check-documentation-build.yml
@@ -8,6 +8,7 @@ on:
       - "docs/**"
       - ".readthedocs.yaml"
       - "setup.py"
+      - "requirements-dev.txt"
       - "VERSION"
       - ".github/workflows/check-documentation-build.yml"
 
@@ -19,6 +20,7 @@ on:
       - "docs/**"
       - ".readthedocs.yaml"
       - "setup.py"
+      - "requirements-dev.txt"
       - "VERSION"
       - ".github/workflows/check-documentation-build.yml"
   
@@ -47,8 +49,8 @@ jobs:
           python-version: '${{ steps.get-version.outputs.python-version }}'
       - name: Update pip
         run: pip install --upgrade pip
-      - name: Install Requirements for building docs
-        run: pip install sphinx readthedocs-sphinx-ext
+      - name: Install Dev Requirements
+        run: pip install -r requirements-dev.txt
       - name: Install SeedFarmer
         run: pip install -e .
       - name: Sphinx Build

--- a/.github/workflows/check-documentation-build.yml
+++ b/.github/workflows/check-documentation-build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Update pip
         run: pip install --upgrade pip
       - name: Install Requirements for building docs
-        run: pip install -r docs/requirements-docs.txt
+        run: pip install sphinx readthedocs-sphinx-ext
       - name: Install SeedFarmer
         run: pip install -e .
       - name: Sphinx Build


### PR DESCRIPTION
### Description

Adding an action that will make sure that the documentation can be built. We previously had this issue, and only discovered it once readthedocs was triggered by a release.


*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
