### PR TITLE
chore: Remove use of deprecated utcnow

### DIFF
--- a/aws_codeseeder/services/cfn.py
+++ b/aws_codeseeder/services/cfn.py
@@ -12,9 +12,9 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import datetime as dt
 import os
 import time
-from datetime import datetime
 from typing import Any, Callable, Dict, Optional, Tuple, Union, cast
 
 import botocore.exceptions
@@ -57,7 +57,7 @@ def _create_changeset(
     parameters: Optional[Dict[str, str]] = None,
     session: Optional[Union[Callable[[], Session], Session]] = None,
 ) -> Tuple[str, str]:
-    now = datetime.utcnow().isoformat()
+    now = dt.datetime.now.isoformat(tz=dt.timezone.utc)
     description = f"Created by AWS CodeSeeder CLI at {now} UTC"
     changeset_name = CHANGESET_PREFIX + str(int(time.time()))
     stack_exist, _ = does_stack_exist(stack_name=stack_name, session=session)

--- a/aws_codeseeder/services/cfn.py
+++ b/aws_codeseeder/services/cfn.py
@@ -57,7 +57,7 @@ def _create_changeset(
     parameters: Optional[Dict[str, str]] = None,
     session: Optional[Union[Callable[[], Session], Session]] = None,
 ) -> Tuple[str, str]:
-    now = dt.datetime.now.isoformat(tz=dt.timezone.utc)
+    now: str = dt.datetime.now(tz=dt.timezone.utc).isoformat()
     description = f"Created by AWS CodeSeeder CLI at {now} UTC"
     changeset_name = CHANGESET_PREFIX + str(int(time.time()))
     stack_exist, _ = does_stack_exist(stack_name=stack_name, session=session)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ line-length = 120
 target-version = "py38"
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I"]
+select = ["E", "W", "F", "I", "DTZ"]
 ignore = []
 fixable = ["ALL"]
 

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -12,7 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from datetime import datetime
+import datetime as dt
 
 from aws_codeseeder import _remote
 from aws_codeseeder.services.codebuild import BuildCloudWatchLogs, BuildInfo, BuildPhaseType, BuildStatus
@@ -29,8 +29,8 @@ def test_run(mocker):
                 build_id="test-xxxxxxxx",
                 status=BuildStatus.succeeded,
                 current_phase=BuildPhaseType.completed,
-                start_time=datetime.utcnow(),
-                end_time=datetime.utcnow(),
+                start_time=dt.datetime.now(dt.timezone.utc),
+                end_time=dt.datetime.now(dt.timezone.utc),
                 duration_in_seconds=1.0,
                 exported_env_vars=[],
                 phases=[],

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -12,7 +12,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import datetime as dt
 import os
 
 import boto3
@@ -225,11 +224,11 @@ def test_cloudwatch_get_log_events(logs_client, session):
         logGroupName="test-group",
         logStreamName="test-stream-0",
         logEvents=[
-            {"timestamp": int(unix_time_millis(dt.datetime.now(dt.timezone.utc))), "message": "test-message-0"},
-            {"timestamp": int(unix_time_millis(dt.datetime.now(dt.timezone.utc))), "message": "test-message-1"},
-            {"timestamp": int(unix_time_millis(dt.datetime.now(dt.timezone.utc))), "message": "test-message-2"},
-            {"timestamp": int(unix_time_millis(dt.datetime.now(dt.timezone.utc))), "message": "test-message-3"},
-            {"timestamp": int(unix_time_millis(dt.datetime.now(dt.timezone.utc))), "message": "test-message-4"},
+            {"timestamp": int(unix_time_millis()), "message": "test-message-0"},
+            {"timestamp": int(unix_time_millis()), "message": "test-message-1"},
+            {"timestamp": int(unix_time_millis()), "message": "test-message-2"},
+            {"timestamp": int(unix_time_millis()), "message": "test-message-3"},
+            {"timestamp": int(unix_time_millis()), "message": "test-message-4"},
         ],
     )
     events = cloudwatch.get_log_events(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -12,8 +12,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import datetime as dt
 import os
-from datetime import datetime
 
 import boto3
 import pytest
@@ -225,11 +225,11 @@ def test_cloudwatch_get_log_events(logs_client, session):
         logGroupName="test-group",
         logStreamName="test-stream-0",
         logEvents=[
-            {"timestamp": int(unix_time_millis(datetime.utcnow())), "message": "test-message-0"},
-            {"timestamp": int(unix_time_millis(datetime.utcnow())), "message": "test-message-1"},
-            {"timestamp": int(unix_time_millis(datetime.utcnow())), "message": "test-message-2"},
-            {"timestamp": int(unix_time_millis(datetime.utcnow())), "message": "test-message-3"},
-            {"timestamp": int(unix_time_millis(datetime.utcnow())), "message": "test-message-4"},
+            {"timestamp": int(unix_time_millis(dt.datetime.now(dt.timezone.utc))), "message": "test-message-0"},
+            {"timestamp": int(unix_time_millis(dt.datetime.now(dt.timezone.utc))), "message": "test-message-1"},
+            {"timestamp": int(unix_time_millis(dt.datetime.now(dt.timezone.utc))), "message": "test-message-2"},
+            {"timestamp": int(unix_time_millis(dt.datetime.now(dt.timezone.utc))), "message": "test-message-3"},
+            {"timestamp": int(unix_time_millis(dt.datetime.now(dt.timezone.utc))), "message": "test-message-4"},
         ],
     )
     events = cloudwatch.get_log_events(


### PR DESCRIPTION
### Description
- Remove use of deprecated `utcnow`
- Add ruff rules to check for this


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
