### PR TITLE
Do not depend on pkg_resources/setuptools, prefer native modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - Add support for explicit secret environment variables for mirrors
 
 ### Fixes
+- No longer depends on the `pkg_resources` module being available from the setuptools package.
 
 ### Breaks
 

--- a/aws_codeseeder/__init__.py
+++ b/aws_codeseeder/__init__.py
@@ -15,16 +15,15 @@
 import logging
 import os
 import shutil
+from importlib.metadata import distribution
 from typing import MutableSet, Optional
-
-import pkg_resources
 
 from aws_codeseeder.__metadata__ import __description__, __license__, __title__
 from aws_codeseeder._classes import EnvVar, EnvVarType
 
 __all__ = ["EnvVar", "EnvVarType"]
 
-__version__: str = pkg_resources.get_distribution(__title__).version
+__version__: str = distribution(__title__).version
 
 LOGGER: logging.Logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
If your environment doesn't have `setuptools` installed (to provide the `pkg_resources` module) then the main codeseeder would fail to initialize, two options to fix this were:

1. Add `setuptools` as a requirement of codeseeder itself (instead of depending on it to exist in the environment already).
2. Stop using `pkg_resources`.

I chose the second option since a native module ([`importlib.metadata`](https://docs.python.org/3/library/importlib.metadata.html#importlib.metadata.distribution)) can be used as a replacement (introduced in Python 3.8, which is the minimum version of codeseeder).

Note that this doesn't happen when running in CodeDeploy due to [setuptools being installed in the base image](https://github.com/aws/aws-codebuild-docker-images/blob/2898ad3dfbe414b5a09b5850cedd23ac39d2af2d/ubuntu/standard/6.0/Dockerfile#L224).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
